### PR TITLE
 [JENKINS-71093] Fix UI: dropdown should be displayed over another elements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,16 +1,7 @@
-/*
- See the documentation for more options:
- https://github.com/jenkins-infra/pipeline-library/
-*/
-// This should be updated manually.
-// See: https://www.jenkins.io/changelog-stable/
-def recentLts = '2.303.1'
-
 buildPlugin(
-  configurations: [
-    [ platform: 'linux', jdk: '8' ],
-    [ platform: 'windows', jdk: '8' ],
-    [ platform: 'linux', jdk: '11', jenkins: recentLts ],
-  ],
   useContainerAgent: true,
-)
+  configurations: [
+    [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.24</version>
+        <version>4.61</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -14,8 +14,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <!-- Recommended versions: https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions -->
-        <jenkins.version>2.289.1</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.361.4</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <name>Editable Choice Plugin</name>
@@ -43,8 +42,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.277.x</artifactId>
-                <version>937.v51fde92016ed</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>2025.v816d28f1e04f</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/resources/io/jenkins/plugins/editable_choice/taglib/suggestInput/suggestInput.css
+++ b/src/main/resources/io/jenkins/plugins/editable_choice/taglib/suggestInput/suggestInput.css
@@ -16,6 +16,7 @@
 }
 
 .editable-choice-suggest .editable-choice-suggest-choices {
+  z-index: 999;
   display: none;
   position: absolute;
   width: 100%;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

https://issues.jenkins.io/browse/JENKINS-71093

![screenshot-2](https://user-images.githubusercontent.com/3115961/235014442-4019acbb-a1cf-4bfb-9521-58f3ab6d0b9c.png)

Dropdown menu is displayed under another elements, e.g. a next parameter. It prevents users from clicking choices.
It looks happen since Jenkins-2.346.1, which modernizes UIs.
Fixed adding z-index.

This change also updates target Jenkins core to 2.361.x, which was 2.289.1.
