### PR TITLE
[JENKINS-71753] FIXED: clicking choices doesn't work

### DIFF
--- a/src/main/resources/io/jenkins/plugins/editable_choice/taglib/suggestInput/suggestInput.js
+++ b/src/main/resources/io/jenkins/plugins/editable_choice/taglib/suggestInput/suggestInput.js
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', function() {
         function() {
           self.stopSuggesting();
         },
-        100
+        500
       );
     });
     this.textbox.addEventListener('keydown', function(evt) {


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-71753

Before this fix:

![01-beforefix](https://github.com/jenkinsci/editable-choice-plugin/assets/3115961/7b8a47ee-076d-4b32-9a88-4093fb9b9b81)

After this fix:

![02-afterfix](https://github.com/jenkinsci/editable-choice-plugin/assets/3115961/e9800ffd-97ca-4329-9b63-12d21674f92a)

Context:
* Focusing the textbox should open choices. And losing focus from the textbox should close choices.
* Though clicking a choice should update the textbox, it also results losing focus from the textbox.
* HTML fires events in following order: `blur` for the textbox, and then `click` for the choice.
* Closing choices in `blur` event prevents `click` for the choice from fired.
* So this plugin calls `setTimeout()` in `blur` event and performs delayed choices-closing.
* Though this delay worked correct with 100ms before, it now no longer work as expected (just as attached animations).
* This change makes the delay longer. After some tests, it requires 500ms delay.

This is just a workaround, and depends on the behaviors of browsers. There's no fundamental solution for this issue.

### Testing done

* No test code for this change. Unfortunately, I couldn't reproduce the issue with test codes.
* I tested the behaviors manually:
    * Firefox 116.0.2 (64 bits) / Windows 11 Home 22H2 (22621.1992)
    * Chrome 115.0.5790.171 (64 bits) / Windows 11 Home 22H2 (22621.1992)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
