### PR TITLE
fix typo in `description`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -48,7 +48,7 @@ Full pipeline example:
 ```
 editableChoice(
   name: 'PARAM1',
-  description: 'Choose your favorite fruit`
+  description: 'Choose your favorite fruit',
   choices: ['Apple', 'Grape', 'Orange'],
   defaultValue: 'Grape',
   restrict: true,


### PR DESCRIPTION
fix typo of back-tick instead of single quote

### Testing done
N/A. This is minor typo in the top-level README